### PR TITLE
Webpush notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+
+appsettings.*.json

--- a/Models.fs
+++ b/Models.fs
@@ -13,6 +13,9 @@ type MessageModel =
 type CreateMessageModel = { ChatId: int; Text: string }
 
 [<CLIMutable>]
+type WebPushSubscriptionModel = { ChatId: int; Json: string }
+
+[<CLIMutable>]
 type Chat =
     { ChatId: int
       Messages: List<MessageModel> }

--- a/Routing.fs
+++ b/Routing.fs
@@ -5,6 +5,7 @@ module Routing =
     open Giraffe
     open Microsoft.AspNetCore.Http
     open HttpHandlers
+    open WebPush
 
     let notLoggedIn = RequestErrors.UNAUTHORIZED "Basic" "" "You must be logged in."
 
@@ -24,7 +25,9 @@ module Routing =
                         subRoute "/db" (choose [ GET >=> updateSchema ])
                         subRoute "/messages" mustBeLoggedIn >=> (messages)
                         subRoute "/user/me" mustBeLoggedIn
-                        >=> (choose[GET >=> handleGetUserMe
-                                    PATCH >=> handleUpdateMeProfile])
-                        subRoute "/callback" mustBeLoggedIn >=> (handleCallback) ])
+                        >=> (choose [ GET >=> handleGetUserMe; PATCH >=> handleUpdateMeProfile ])
+                        subRoute "/callback" mustBeLoggedIn >=> (handleCallback)
+                        subRoute "/web-push/subscribe" mustBeLoggedIn >=> (handleNewSubscription)
+                        subRoute "/web-push/key" mustBeLoggedIn >=> (handleGetVapidKey) ])
+              // subRoute "/web-push/custom-message" mustBeLoggedIn >=> (handlePushCustomMessage) ])
               setStatusCode 404 >=> text "Not Found" ]

--- a/SigmaChatServer.fsproj
+++ b/SigmaChatServer.fsproj
@@ -12,13 +12,16 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
     <PackageReference Include="Microsoft.IdentityModel" Version="7.0.0" />
     <PackageReference Include="Npgsql" Version="8.0.0" />
+    <PackageReference Include="WebPush" Version="1.0.12" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models.fs" />
     <Compile Include="sql/Migrations.fs" />
     <Compile Include="sql/ChatDb.fs" />
     <Compile Include="sql/UserDb.fs" />
+    <Compile Include="sql\WebPushDb.fs" />
     <Compile Include="Hub.fs" />
+    <Compile Include="WebPush.fs" />
     <Compile Include="HttpHandlers.fs" />
     <Compile Include="Routing.fs" />
     <Compile Include="Program.fs" />

--- a/WebPush.fs
+++ b/WebPush.fs
@@ -1,0 +1,103 @@
+namespace SigmaChatServer
+
+module WebPush =
+    open WebPush
+    open Microsoft.AspNetCore.Http
+    open Giraffe
+    open ChatDb
+    open WebPushDb
+    open Microsoft.Extensions.Configuration
+    open SigmaChatServer.Models
+    open System.Text.Json.Nodes
+    open Newtonsoft.Json.Linq
+    open System.Threading.Tasks
+    open System.Collections.Generic
+    open System.Text.Json
+
+    let private getVapidDetails (configuration: IConfiguration) =
+        let vapidSection = configuration.GetSection("Vapid")
+        let vapidPublic = vapidSection.["Public"]
+        let vapidPrivate = vapidSection.["Private"]
+        let vapidSubject = vapidSection.["Subject"]
+
+        new VapidDetails(vapidSubject, vapidPublic, vapidPrivate)
+
+    let private pushPayload (subscription: PushSubscription) (vapidDetails: VapidDetails) (payload: string) =
+        task {
+            let webPushClient = new WebPushClient()
+            return! webPushClient.SendNotificationAsync(subscription, payload, vapidDetails)
+        }
+
+    let private parseSubscription (json: string) =
+        let j = JObject.Parse json
+
+        new PushSubscription(
+            j.SelectToken "endpoint" |> string,
+            j.SelectToken "keys.p256dh" |> string,
+            j.SelectToken "keys.auth" |> string
+        )
+
+    let webpushMessageForUser (ctx: HttpContext) (userId: string) (createdMessageModel: CreateMessageModel) =
+        task {
+            let! subscriptionEntity = getSubscription ctx userId
+            let configuration = ctx.GetService<IConfiguration>()
+
+            let payload =
+                JsonSerializer.Serialize
+                    {| title = createdMessageModel.Text
+                       // probable svg wont work todo test this
+                       icon = "https://sigmachat.cc/cc.svg" |}
+
+            return!
+                match subscriptionEntity with
+                // todo add logging
+                | None -> task { return () }
+                | Some sub ->
+                    let parsedSubscription = parseSubscription sub.Json
+                    let vapidDetails = getVapidDetails configuration
+                    pushPayload parsedSubscription vapidDetails payload
+        }
+
+    let handleNewSubscription (next: HttpFunc) (ctx: HttpContext) =
+        task {
+            let userId = ctx.User.Identity.Name
+            let! subJson = ctx.ReadBodyFromRequestAsync()
+
+            do! insertSubscription ctx subJson userId
+
+            return! json None next ctx
+        }
+
+    let handleGetVapidKey (next: HttpFunc) (ctx: HttpContext) =
+        let configuration = ctx.GetService<IConfiguration>()
+
+        let vapidSection = configuration.GetSection("Vapid")
+        let vapidPublic = vapidSection.["Public"]
+
+        task { return! json {| PublicKey = vapidPublic |} next ctx }
+
+    let handlePushCustomMessage (next: HttpFunc) (ctx: HttpContext) =
+        task {
+            let! message = ctx.ReadBodyFromRequestAsync()
+            let configuration = ctx.GetService<IConfiguration>()
+
+            let! parsedSubscriptions = getAllSubscriptions ctx
+            let vapidDetails = getVapidDetails configuration
+
+            let subs =
+                parsedSubscriptions |> List.ofSeq |> Seq.map (fun a -> parseSubscription a.Json)
+
+
+            let payload =
+                JsonSerializer.Serialize
+                    {| title = message
+                       options = {| body = message |} |}
+
+            let! z =
+                Task.WhenAll(
+                    subs
+                    |> Seq.map (fun subscription -> pushPayload subscription vapidDetails payload)
+                )
+
+            return! json None next ctx
+        }

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,5 +1,10 @@
 {
   "DbConnectionString": "User ID=sa;Password=JHVHjhvh!;Host=localhost;Port=5432;Database=SigmaChatDb;Pooling=true;Minimum Pool Size=0;Maximum Pool Size=100;Connection Lifetime=0;SSL Mode=Disable;Trust Server Certificate=true",
+  "Vapid":{
+    "Subject":"",
+    "Private":"",
+    "Public":""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/sql/Migrations.fs
+++ b/sql/Migrations.fs
@@ -13,7 +13,7 @@ module Migrations =
             CREATE TABLE "Migrations"(
                 "Version" INT PRIMARY KEY
             );
-        """
+            """
            """
             CREATE TABLE "Chats"(
                 "ChatId" serial PRIMARY KEY
@@ -30,7 +30,7 @@ module Migrations =
                 FOREIGN KEY ("ChatId")
                     REFERENCES "Chats" ("ChatId")
             );
-        """
+            """
            """
             CREATE TABLE "Users"(
                 "Id" VARCHAR(50) PRIMARY KEY,
@@ -41,4 +41,14 @@ module Migrations =
             ALTER TABLE "Messages"
             DROP COLUMN "Sender",
             ADD COLUMN "UserId" VARCHAR(50) NOT NULL REFERENCES "Users"("Id");
-         """ |]
+            """
+           """
+            CREATE TABLE "PushSubscriptions"(
+                "Id" serial PRIMARY KEY,
+                "UserId" VARCHAR(50),
+                "Json" VARCHAR(4000),
+                "DateCreated" TIMESTAMP NOT NULL,
+                FOREIGN KEY ("UserId")
+                    REFERENCES "Users" ("Id")
+            );
+            """ |]

--- a/sql/WebPushDb.fs
+++ b/sql/WebPushDb.fs
@@ -1,0 +1,56 @@
+namespace SigmaChatServer
+
+module WebPushDb =
+    open Microsoft.AspNetCore.Http
+    open Giraffe
+    open System.Data
+    open Dapper
+    open SigmaChatServer.Models
+    open System
+    open Microsoft.FSharp.Core
+
+    let insertSubscription (ctx: HttpContext) (json: string) (userId: string) =
+        task {
+            use connection = ctx.GetService<IDbConnection>()
+
+            let sql =
+                """
+                INSERT INTO "PushSubscriptions" ( "UserId", "Json", "DateCreated") VALUES ( @userId, @json, NOW());
+                """
+
+            let sqlParams = {| userId = userId; json = json |}
+
+            let! _ = connection.ExecuteScalarAsync<int>(sql, sqlParams)
+
+            return ()
+        }
+
+    let getSubscription (ctx: HttpContext) (userId: string) =
+        task {
+            use connection = ctx.GetService<IDbConnection>()
+
+            //WHERE "UserId"= @userId
+            let sql =
+                """SELECT * FROM "PushSubscriptions" 
+                    ORDER BY "DateCreated" DESC
+                    LIMIT 1;"""
+
+            let data = {| userId = userId |}
+
+            try
+                let! subscription = connection.QueryFirstAsync<WebPushSubscriptionModel>(sql, data)
+                return Some subscription
+            with :? InvalidOperationException ->
+                return None
+        }
+
+    let getAllSubscriptions (ctx: HttpContext) =
+        task {
+            use connection = ctx.GetService<IDbConnection>()
+
+            let sql =
+                """SELECT * FROM "PushSubscriptions";"""
+
+            let! subscriptions = connection.QueryAsync<WebPushSubscriptionModel>(sql)
+            return subscriptions
+        }


### PR DESCRIPTION
Changed handling of returning no result queries from returning some wild null values unsupported by F# to try catching not OrDefault query and returning Option.

Added webpush implemented with C# webpush lib. Its super annoying rn though, theres no limitng on notifications so it will spam users even on their own messages. Added table for storing subscription instances which probably can use some work- maybe put it for each user no reason to hold old ones.

Added commented out admin endpoint for testing webpush sending message to everyone. Added ignore rule to gitignore for appsettings for specific env.